### PR TITLE
roles/borgbackup: run the backups using borgmatic

### DIFF
--- a/roles/borgbackup/files/config.yaml
+++ b/roles/borgbackup/files/config.yaml
@@ -1,0 +1,38 @@
+repositories:
+  - label: rsync.net
+    path: ssh://19678@ch-s012.rsync.net:22/data2/home/19678/ruby/
+
+ssh_command: 'ssh -i /root/.ssh/borgkey'
+remote_path: borg14
+
+encryption_passphrase: '{credential file /etc/borgmatic/credentials/rsync.net.txt}'
+
+source_directories:
+  - /
+one_file_system: true
+exclude_caches: true
+exclude_patterns:
+  - '*.pyc'
+  - '/home/*/.cache/'
+  - '/var/log/borgbackup/'
+  - '/var/lib/apt/lists/'
+  - '/var/cache/'
+  - '/var/tmp/'
+  - '/srv/efs/'
+  - '/srv/backup/'
+  - '/tmp'
+
+archive_name_format: '{hostname}-{now:%Y-%m-%dT%H:%M:%S}'
+match_archives: '{hostname}-*'
+compression: lz4
+
+## These options require borgmatic 2.0
+#statistics: true
+#list_details: true
+#file_list_option: AME
+#log_file: /var/log/borgbackup/bogmatic.log
+
+keep_daily: 7
+keep_weekly: 4
+keep_monthly: -1
+keep_yearly: -1

--- a/roles/borgbackup/tasks/main.yml
+++ b/roles/borgbackup/tasks/main.yml
@@ -47,10 +47,11 @@
     key: ch-s012.rsync.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO5lfML3qjBiDXi4yh3xPoXPHqIOeLNp66P3Unrl+8g3
     path: /root/.ssh/known_hosts
 
-- name: Enable daily backups via cron
+- name: Disable old daily backups via cron
   file:
-    state: link
-    src: /root/bin/borgauto.sh
+    state: absent
+    #state: link
+    #src: /root/bin/borgauto.sh
     dest: /etc/cron.daily/borgbackup
 
 - name: Create borgmatic config directory
@@ -80,8 +81,8 @@
 - name: Install borgmatic config
   copy:
     src: config.yaml
-    #dest: /etc/borgmatic/config.yaml
-    dest: /home/glass/borgmatic-config.yaml
+    dest: /etc/borgmatic/config.yaml
+    #dest: /home/glass/borgmatic-config.yaml
     owner: root
     group: root
     mode: 0755

--- a/roles/borgbackup/tasks/main.yml
+++ b/roles/borgbackup/tasks/main.yml
@@ -2,6 +2,7 @@
   apt:
     name:
       - borgbackup
+      - borgmatic
       - fuse
     state: latest
 
@@ -51,3 +52,36 @@
     state: link
     src: /root/bin/borgauto.sh
     dest: /etc/cron.daily/borgbackup
+
+- name: Create borgmatic config directory
+  file:
+    path: /etc/borgmatic
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Create borgmatic config directory
+  file:
+    path: /etc/borgmatic/credentials
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Install borgmatic rsync.net credentials
+  copy:
+    content: "{{ borg_passphrase }}"
+    dest: /etc/borgmatic/credentials/rsync.net.txt
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Install borgmatic config
+  copy:
+    src: config.yaml
+    #dest: /etc/borgmatic/config.yaml
+    dest: /home/glass/borgmatic-config.yaml
+    owner: root
+    group: root
+    mode: 0755


### PR DESCRIPTION
Currently we have a shell script calling borg to perform our backups. This PR switches to using the borgmatic wrapper script, so we can manage the backup settings in a config file, and integrate database backups (needed for a future Mailman 3 upgrade).

Fixes #23